### PR TITLE
Misc. updates, upstreaming Figma version

### DIFF
--- a/webgl-recorder.js
+++ b/webgl-recorder.js
@@ -112,7 +112,7 @@
                   }
 
                   else {
-                    console.warn('unsupported value:', arg);
+                    console.warn('unsupported value:', arg, `in call to ${name}.${key}`);
                     return 'null';
                   }
                 }

--- a/webgl-recorder.js
+++ b/webgl-recorder.js
@@ -13,16 +13,16 @@
   };
 
   HTMLCanvasElement.prototype.getContext = function(type) {
-    var canvas = this;
-    var context = getContext.apply(canvas, arguments);
+    const canvas = this;
+    const context = getContext.apply(canvas, arguments);
 
     if (type === 'webgl' || type === 'experimental-webgl') {
-      var oldWidth = canvas.width;
-      var oldHeight = canvas.height;
-      var oldFrameCount = frameSincePageLoad;
-      var trace = [];
-      var variables = {};
-      var fakeContext = {
+      let oldWidth = canvas.width;
+      let oldHeight = canvas.height;
+      let oldFrameCount = frameSincePageLoad;
+      const trace = [];
+      const variables = {};
+      let fakeContext = {
         trace: trace,
         compileTrace: compileTrace,
         downloadTrace: downloadTrace,
@@ -32,10 +32,10 @@
       trace.push('  gl.canvas.height = ' + oldHeight + ';');
 
       function compileTrace() {
-        var text = 'function* render(gl) {\n';
+        let text = 'function* render(gl) {\n';
         text += '  // Recorded using https://github.com/evanw/webgl-recorder\n';
-        for (var key in variables) {
-          text += '  var ' + key + 's = [];\n';
+        for (let key in variables) {
+          text += '  const ' + key + 's = [];\n';
         }
         text += trace.join('\n');
         text += '\n}\n';
@@ -43,8 +43,8 @@
       }
 
       function downloadTrace() {
-        var text = compileTrace();
-        var link = document.createElement('a');
+        const text = compileTrace();
+        const link = document.createElement('a');
         link.href = URL.createObjectURL(new Blob([text], {type: 'application/javascript'}));
         link.download = 'trace.js';
         document.body.appendChild(link);
@@ -62,9 +62,9 @@
             value instanceof WebGLShaderPrecisionFormat ||
             value instanceof WebGLTexture ||
             value instanceof WebGLUniformLocation) {
-          var name = value.constructor.name;
-          var list = variables[name] || (variables[name] = []);
-          var index = list.indexOf(value);
+          const name = value.constructor.name;
+          const list = variables[name] || (variables[name] = []);
+          let index = list.indexOf(value);
 
           if (index === -1) {
             index = list.length;
@@ -77,14 +77,14 @@
         return null;
       }
 
-      for (var key in context) {
-        var value = context[key];
+      for (const key in context) {
+        const value = context[key];
 
         if (typeof value === 'function') {
           fakeContext[key] = function(key, value) {
             return function() {
-              var result = value.apply(context, arguments);
-              var args = [];
+              const result = value.apply(context, arguments);
+              const args = [];
 
               if (frameSincePageLoad !== oldFrameCount) {
                 oldFrameCount = frameSincePageLoad;
@@ -98,8 +98,8 @@
                 trace.push('  gl.canvas.height = ' + oldHeight + ';');
               }
 
-              for (var i = 0; i < arguments.length; i++) {
-                var arg = arguments[i];
+              for (let i = 0; i < arguments.length; i++) {
+                const arg = arguments[i];
 
                 if (typeof arg === 'number' || typeof arg === 'boolean' || typeof arg === 'string' || arg === null) {
                   args.push(JSON.stringify(arg));
@@ -110,7 +110,7 @@
                 }
 
                 else {
-                  var variable = getVariable(arg);
+                  const variable = getVariable(arg);
                   if (variable !== null) {
                     args.push(variable);
                   }
@@ -122,8 +122,8 @@
                 }
               }
 
-              var text = 'gl.' + key + '(' + args.join(', ') + ');';
-              var variable = getVariable(result);
+              let text = 'gl.' + key + '(' + args.join(', ') + ');';
+              const variable = getVariable(result);
               if (variable !== null) text = variable + ' = ' + text;
               trace.push('  ' + text);
 

--- a/webgl-recorder.js
+++ b/webgl-recorder.js
@@ -64,7 +64,7 @@
             value instanceof WebGLUniformLocation ||
             value instanceof WebGLVertexArrayObject ||
             // In Chrome, value won't be an instanceof WebGLVertexArrayObject.
-            (value && value.constructor.name === "WebGLVertexArrayObjectOES") ||
+            (value && value.constructor.name == "WebGLVertexArrayObjectOES") ||
             typeof value === 'object') {
           const name = value.constructor.name;
           const list = variables[name] || (variables[name] = []);

--- a/webgl-recorder.js
+++ b/webgl-recorder.js
@@ -96,29 +96,27 @@
                 trace.push('  gl.canvas.height = ' + oldHeight + ';');
               }
 
-              for (let i = 0; i < arguments.length; i++) {
-                const arg = arguments[i];
-
+              const args = Array.prototype.map.call(arguments, arg => {
                 if (typeof arg === 'number' || typeof arg === 'boolean' || typeof arg === 'string' || arg === null) {
-                  args.push(JSON.stringify(arg));
+                  return JSON.stringify(arg);
                 }
 
                 else if (ArrayBuffer.isView(arg)) {
-                  args.push('new ' + arg.constructor.name + '([' + Array.prototype.slice.call(arg) + '])');
+                  return 'new ' + arg.constructor.name + '([' + Array.prototype.slice.call(arg) + '])';
                 }
 
                 else {
                   const variable = getVariable(arg);
                   if (variable !== null) {
-                    args.push(variable);
+                    return variable;
                   }
 
                   else {
                     console.warn('unsupported value:', arg);
-                    args.push('null');
+                    return 'null';
                   }
                 }
-              }
+              });
 
               let text = `${name}.${key}(${args.join(', ')});`;
               const variable = getVariable(result);

--- a/webgl-recorder.js
+++ b/webgl-recorder.js
@@ -102,7 +102,7 @@
                 }
 
                 else if (ArrayBuffer.isView(arg)) {
-                  return 'new ' + arg.constructor.name + '([' + Array.prototype.slice.call(arg) + '])';
+                  return `new ${arg.constructor.name}([${Array.prototype.slice.call(arg)}])`;
                 }
 
                 else {
@@ -120,7 +120,7 @@
 
               let text = `${name}.${key}(${args.join(', ')});`;
               const variable = getVariable(result);
-              if (variable !== null) text = variable + ' = ' + text;
+              if (variable !== null) text = `${variable} = ${text}`;
               trace.push('  ' + text);
 
               if (result === null) return null;

--- a/webgl-recorder.js
+++ b/webgl-recorder.js
@@ -61,7 +61,11 @@
             value instanceof WebGLShader ||
             value instanceof WebGLShaderPrecisionFormat ||
             value instanceof WebGLTexture ||
-            value instanceof WebGLUniformLocation) {
+            value instanceof WebGLUniformLocation ||
+            value instanceof WebGLVertexArrayObject ||
+            // In Chrome, value won't be an instanceof WebGLVertexArrayObject.
+            (value && value.constructor.name === "WebGLVertexArrayObjectOES") ||
+            typeof value === 'object') {
           const name = value.constructor.name;
           const list = variables[name] || (variables[name] = []);
           let index = list.indexOf(value);

--- a/webgl-recorder.js
+++ b/webgl-recorder.js
@@ -99,19 +99,13 @@
               const args = Array.prototype.map.call(arguments, arg => {
                 if (typeof arg === 'number' || typeof arg === 'boolean' || typeof arg === 'string' || arg === null) {
                   return JSON.stringify(arg);
-                }
-
-                else if (ArrayBuffer.isView(arg)) {
+                } else if (ArrayBuffer.isView(arg)) {
                   return `new ${arg.constructor.name}([${Array.prototype.slice.call(arg)}])`;
-                }
-
-                else {
+                } else {
                   const variable = getVariable(arg);
                   if (variable !== null) {
                     return variable;
-                  }
-
-                  else {
+                  } else {
                     console.warn('unsupported value:', arg, `in call to ${name}.${key}`);
                     return 'null';
                   }


### PR DESCRIPTION
We needed to update the version of webgl-recorder used in Figma because over time we ended up relying on more properties of the WebGLContext than webgl-recorder reproduces with its 'fake context'. This PR upstreams those changes as well as some code modernization.