### PR TITLE
Add support for WebGL 2 and switch to ES6 Proxies

### DIFF
--- a/webgl-recorder.js
+++ b/webgl-recorder.js
@@ -1,4 +1,5 @@
 (function () {
+  var contexts = new WeakMap();
   var getContext = HTMLCanvasElement.prototype.getContext;
   var requestAnimationFrame = window.requestAnimationFrame;
   var frameSincePageLoad = 0;
@@ -16,32 +17,43 @@
     const canvas = this;
     const context = getContext.apply(canvas, arguments);
 
-    if (type === 'webgl' || type === 'experimental-webgl') {
+    if (
+      type === "webgl" ||
+      type === "experimental-webgl" ||
+      type === "webgl2"
+    ) {
+      if (!context) return null;
+      if (contexts.has(context)) return contexts.get(context);
+
       let oldWidth = canvas.width;
       let oldHeight = canvas.height;
       let oldFrameCount = frameSincePageLoad;
       const trace = [];
       const variables = {};
 
-      trace.push('  gl.canvas.width = ' + oldWidth + ';');
-      trace.push('  gl.canvas.height = ' + oldHeight + ';');
+      trace.push("  gl.canvas.width = " + oldWidth + ";");
+      trace.push("  gl.canvas.height = " + oldHeight + ";");
 
       function compileTrace() {
-        let text = 'function* render(gl) {\n';
-        text += '  // Recorded using https://github.com/evanw/webgl-recorder\n';
+        let text = "function* render(gl) {\n";
+        text += "  // Recorded using https://github.com/evanw/webgl-recorder\n";
         for (let key in variables) {
-          text += '  const ' + key + 's = [];\n';
+          text += "  const " + key + "s = [];\n";
         }
-        text += trace.join('\n');
-        text += '\n}\n';
+        text += trace.join("\n");
+        text += "\n}\n";
         return text;
       }
 
       function downloadTrace() {
         const text = compileTrace();
-        const link = document.createElement('a');
-        link.href = URL.createObjectURL(new Blob([text], { type: 'application/javascript' }));
-        link.download = 'trace.js';
+        const link = document.createElement("a");
+        link.href = URL.createObjectURL(
+          new Blob([text], {
+            type: "application/javascript",
+          }),
+        );
+        link.download = "trace.js";
         document.body.appendChild(link);
         link.click();
         document.body.removeChild(link);
@@ -61,7 +73,7 @@
           value instanceof WebGLVertexArrayObject ||
           // In Chrome, value won't be an instanceof WebGLVertexArrayObject.
           (value && value.constructor.name == "WebGLVertexArrayObjectOES") ||
-          typeof value === 'object'
+          typeof value === "object"
         ) {
           const name = value.constructor.name;
           const list = variables[name] || (variables[name] = []);
@@ -72,87 +84,92 @@
             list.push(value);
           }
 
-          return name + 's[' + index + ']';
+          return name + "s[" + index + "]";
         }
 
         return null;
       }
 
+      const fnMap = { __proto__: null, trace, downloadTrace, compileTrace };
+
       function patch(name, object) {
-        const patched = {};
-        for (const key in object) {
-          const value = object[key];
-          if (typeof value === 'function') {
-            patched[key] = function () {
-              const result = value.apply(object, arguments);
+        return new Proxy(object, {
+          get(target, key) {
+            if (key in fnMap) return fnMap[key];
 
-              if (frameSincePageLoad !== oldFrameCount) {
-                oldFrameCount = frameSincePageLoad;
-                trace.push('  yield;');
-              }
+            const value = Reflect.get(target, key);
+            if (typeof value == "function") {
+              return function () {
+                const result = value.apply(target, arguments);
 
-              if (canvas.width !== oldWidth || canvas.height !== oldHeight) {
-                oldWidth = canvas.width;
-                oldHeight = canvas.height;
-                trace.push('  gl.canvas.width = ' + oldWidth + ';');
-                trace.push('  gl.canvas.height = ' + oldHeight + ';');
-              }
-
-              const argToCode = arg => {
-                if (typeof arg === 'number' || typeof arg === 'boolean' || typeof arg === 'string' || arg === null) {
-                  return JSON.stringify(arg);
-                } else if (ArrayBuffer.isView(arg)) {
-                  return `new ${arg.constructor.name}([${Array.prototype.slice.call(arg)}])`;
-                } else if (arg instanceof ArrayBuffer) {
-                  return `new Uint8Array([${new Uint8Array(arg)}]).buffer`;
-                } else if (Array.isArray(arg)) {
-                  return `[${arg.map(argToCode).join(',')}]`;
-                } else {
-                  const variable = getVariable(arg);
-                  if (variable !== null) {
-                    return variable;
-                  } else {
-                    console.warn('unsupported value:', arg, `in call to ${name}.${key}`);
-                    return 'null';
-                  }
+                if (frameSincePageLoad !== oldFrameCount) {
+                  oldFrameCount = frameSincePageLoad;
+                  trace.push("  yield;");
                 }
+
+                if (canvas.width !== oldWidth || canvas.height !== oldHeight) {
+                  oldWidth = canvas.width;
+                  oldHeight = canvas.height;
+                  trace.push("  gl.canvas.width = " + oldWidth + ";");
+                  trace.push("  gl.canvas.height = " + oldHeight + ";");
+                }
+
+                const argToCode = (arg) => {
+                  if (
+                    typeof arg === "number" ||
+                    typeof arg === "boolean" ||
+                    typeof arg === "string" ||
+                    arg === null
+                  ) {
+                    return JSON.stringify(arg);
+                  } else if (ArrayBuffer.isView(arg)) {
+                    return `new ${arg.constructor.name}([${Array.prototype.slice.call(arg)}])`;
+                  } else if (arg instanceof ArrayBuffer) {
+                    return `new Uint8Array([${new Uint8Array(arg)}]).buffer`;
+                  } else if (Array.isArray(arg)) {
+                    return `[${arg.map(argToCode).join(",")}]`;
+                  } else {
+                    const variable = getVariable(arg);
+                    if (variable !== null) {
+                      return variable;
+                    } else {
+                      console.warn(
+                        "unsupported value:",
+                        arg,
+                        `in call to ${name}.${key}`,
+                      );
+                      return "null";
+                    }
+                  }
+                };
+                const args = Array.prototype.map.call(arguments, argToCode);
+
+                let text = `${name}.${key}(${args.join(", ")});`;
+                const variable = getVariable(result);
+                if (variable !== null) text = `${variable} = ${text}`;
+                trace.push("  " + text);
+
+                if (result === null) return null;
+                if (result === undefined) return undefined;
+                // In Firefox, getExtension returns things with constructor.name == 'Object', but in
+                // Chrome getExtension returns unique constructor.names.
+                if (
+                  result.constructor.name === "Object" ||
+                  key == "getExtension"
+                ) {
+                  return patch(variable, result);
+                }
+                return result;
               };
-              const args = Array.prototype.map.call(arguments, argToCode);
-
-              let text = `${name}.${key}(${args.join(', ')});`;
-              const variable = getVariable(result);
-              if (variable !== null) text = `${variable} = ${text}`;
-              trace.push('  ' + text);
-
-              if (result === null) return null;
-              if (result === undefined) return undefined;
-              // In Firefox, getExtension returns things with constructor.name == 'Object', but in
-              // Chrome getExtension returns unique constructor.names.
-              if (result.constructor.name === 'Object' || key == 'getExtension') {
-                return patch(variable, result);
-              }
-              return result;
-            };
-          } else { // typeof value !== function
-            Object.defineProperty(patched, key, {
-              configurable: false,
-              enumerable: true,
-              get() {
-                return object[key];
-              }
-            });
-          }
-        }
-        return patched;
+            } else {
+              return value;
+            }
+          },
+        });
       }
-
-      const fakeContext = patch('gl', context);
-      Object.assign(fakeContext, {
-        trace: trace,
-        compileTrace: compileTrace,
-        downloadTrace: downloadTrace,
-      });
-      return fakeContext;
+      const proxy = patch("gl", context);
+      contexts.set(context, proxy);
+      return proxy;
     }
 
     return context;


### PR DESCRIPTION
This PR adds support for WebGL 2 by checking for webgl2 type, as well as switches from bespoke patching to ES6 proxies.